### PR TITLE
Fixing Jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
The Jitpack build would fail before as it's using OpemJDK 8 by default  :

bad class file: /home/jitpack/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty.websocket/websocket-jetty-api/11.0.13/8ff0dac68f61f3a6bccb944f2f19ee8db3684ec6/websocket-jetty-api-11.0.13.jar(org/eclipse/jetty/websocket/api/Session.class)
    class file has wrong version 55.0, should be 52.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.

Setting it to OpenJDK 11 solved the issue (example of successful build : https://jitpack.io/com/github/YohBur/obs-websocket-java/develop-06f26f1e2b-1/build.log) 
